### PR TITLE
Fixed deploy script not restoring NPM packages before deploying.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -3,6 +3,8 @@ sam_template_file='template.yaml'
 cf_stack_name=focusmark-"$deployed_environment"-cf-api-workbook-domainmapping
 cf_template_file='domain-mapping.yaml'
 
+npm install lambda --prefix lambda
+
 sam deploy \
   --template-file $sam_template_file \
   --stack-name $sam_stack_name \


### PR DESCRIPTION
Added npm restore as part of the build steps so the SAM CLI can upload the final package with all of it's dependencies correctly.